### PR TITLE
Update Nexus version and requirements

### DIFF
--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -154,14 +154,14 @@ parameters:
 - displayName: Sonatype Nexus version
   name: NEXUS_VERSION
   required: true
-  value: 3.15.0
+  value: 3.16.2
 - description: Volume space available for Sonatype Nexus e.g. 512Mi, 2Gi
   displayName: Volume Space for Nexus
   name: VOLUME_CAPACITY
   required: true
-  value: 2Gi
+  value: 5Gi
 - description: Max memory allocated to the Nexus pod
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 1Gi
+  value: 2Gi

--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -154,7 +154,7 @@ parameters:
 - displayName: Sonatype Nexus version
   name: NEXUS_VERSION
   required: true
-  value: 3.6.0
+  value: 3.15.0
 - description: Volume space available for Sonatype Nexus e.g. 512Mi, 2Gi
   displayName: Volume Space for Nexus
   name: VOLUME_CAPACITY

--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -59,7 +59,7 @@ objects:
               - echo
               - ok
             failureThreshold: 3
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -73,7 +73,7 @@ objects:
               path: /
               port: 8081
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -89,7 +89,7 @@ objects:
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
-        terminationGracePeriodSeconds: 30
+        terminationGracePeriodSeconds: 60
         volumes:
         - name: ${SERVICE_NAME}-data
           persistentVolumeClaim:

--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -40,7 +40,7 @@ objects:
             command:
               - "/bin/bash"
               - "-c"
-              - "curl -o /tmp/nexus-functions -s https://raw.githubusercontent.com/OpenShiftDemos/nexus/master/scripts/nexus-functions; source /tmp/nexus-functions; add_nexus3_redhat_repos admin admin123 http://${SERVICE_NAME}:8081"
+              - "curl -o /tmp/nexus-functions -s https://raw.githubusercontent.com/kenmoini/openshift-sonatype-nexus/master/scripts/nexus-functions; source /tmp/nexus-functions; add_nexus3_redhat_repos admin admin123 http://${SERVICE_NAME}:8081"
       type: Recreate
     template:
       metadata:

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -151,4 +151,4 @@ parameters:
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 1Gi
+  value: 2Gi

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -44,7 +44,7 @@ objects:
             command:
               - "/bin/bash"
               - "-c"
-              - "curl -o /tmp/nexus-functions -s https://raw.githubusercontent.com/OpenShiftDemos/nexus/master/scripts/nexus-functions; source /tmp/nexus-functions; add_nexus3_redhat_repos admin admin123 http://${SERVICE_NAME}:8081"
+              - "curl -o /tmp/nexus-functions -s https://raw.githubusercontent.com/kenmoini/openshift-sonatype-nexus/master/scripts/nexus-functions; source /tmp/nexus-functions; add_nexus3_redhat_repos admin admin123 http://${SERVICE_NAME}:8081"
       type: Rolling
     template:
       metadata:

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -146,7 +146,7 @@ parameters:
   name: NEXUS_VERSION
   required: true
   #value: 3.6.0
-  value: 3.18.1
+  value: 3.15.1
 - description: Max memory allocated to the Nexus pod
   displayName: Max Memory
   name: MAX_MEMORY

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -63,7 +63,7 @@ objects:
               - echo
               - ok
             failureThreshold: 3
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -77,7 +77,7 @@ objects:
               path: /
               port: 8081
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -93,7 +93,7 @@ objects:
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
-        terminationGracePeriodSeconds: 30
+        terminationGracePeriodSeconds: 60
         volumes:
         - name: ${SERVICE_NAME}-data
           emptyDir: {}

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -145,8 +145,7 @@ parameters:
 - displayName: Sonatype Nexus version
   name: NEXUS_VERSION
   required: true
-  #value: 3.6.0
-  value: 3.15.1
+  value: 3.16.2
 - description: Max memory allocated to the Nexus pod
   displayName: Max Memory
   name: MAX_MEMORY

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -145,7 +145,8 @@ parameters:
 - displayName: Sonatype Nexus version
   name: NEXUS_VERSION
   required: true
-  value: 3.6.0
+  #value: 3.6.0
+  value: 3.18.1
 - description: Max memory allocated to the Nexus pod
   displayName: Max Memory
   name: MAX_MEMORY


### PR DESCRIPTION
Big warnings about security exploits when using this to deploy.

So I spent about 2 hours testing different versions up to the last known good configuration that works in the DevSecOps workshop.

Newer versions need moar RAM too, takes a little longer to provision.

3.16.2 is the last good and known working, non-vulnerable version.