### PR TITLE
Update versions and resource requirements

### DIFF
--- a/nexus3-persistent-template.yaml
+++ b/nexus3-persistent-template.yaml
@@ -59,7 +59,7 @@ objects:
               - echo
               - ok
             failureThreshold: 3
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -73,7 +73,7 @@ objects:
               path: /
               port: 8081
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -89,7 +89,7 @@ objects:
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
-        terminationGracePeriodSeconds: 30
+        terminationGracePeriodSeconds: 60
         volumes:
         - name: ${SERVICE_NAME}-data
           persistentVolumeClaim:
@@ -154,14 +154,14 @@ parameters:
 - displayName: Sonatype Nexus version
   name: NEXUS_VERSION
   required: true
-  value: 3.6.0
+  value: 3.16.2
 - description: Volume space available for Sonatype Nexus e.g. 512Mi, 2Gi
   displayName: Volume Space for Nexus
   name: VOLUME_CAPACITY
   required: true
-  value: 2Gi
+  value: 5Gi
 - description: Max memory allocated to the Nexus pod
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 1Gi
+  value: 2Gi

--- a/nexus3-template.yaml
+++ b/nexus3-template.yaml
@@ -35,7 +35,7 @@ objects:
         intervalSeconds: 1
         maxSurge: 25%
         maxUnavailable: 0
-        timeoutSeconds: 600
+        timeoutSeconds: 660
         updatePeriodSeconds: 1
         post:
           failurePolicy: Abort
@@ -63,7 +63,7 @@ objects:
               - echo
               - ok
             failureThreshold: 3
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -77,7 +77,7 @@ objects:
               path: /
               port: 8081
               scheme: HTTP
-            initialDelaySeconds: 30
+            initialDelaySeconds: 60
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
@@ -93,7 +93,7 @@ objects:
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}
-        terminationGracePeriodSeconds: 30
+        terminationGracePeriodSeconds: 60
         volumes:
         - name: ${SERVICE_NAME}-data
           emptyDir: {}
@@ -145,9 +145,9 @@ parameters:
 - displayName: Sonatype Nexus version
   name: NEXUS_VERSION
   required: true
-  value: 3.6.0
+  value: 3.16.2
 - description: Max memory allocated to the Nexus pod
   displayName: Max Memory
   name: MAX_MEMORY
   required: true
-  value: 1Gi
+  value: 2Gi


### PR DESCRIPTION
Big warnings about security exploits when using this template to deploy.

So I tested different versions up to the last known good configuration that works in the DevSecOps workshop.

Newer versions need moar RAM too, takes a little longer to provision as well.

3.16.2 is the last good and known working, non-vulnerable version.  It's also only 2 minor versions behind as of right now so that's cool.

Further than this version, there seems to be a change in how things are initialized in Nexus as the init script doesn't perform the needed admin + repo add functions so the pipeline will fail when trying to find nexus:8081/repositories/maven-all-public.  Tried changing to maven-all in the JAX Tasks application but it would still fail. *shrugs*